### PR TITLE
Disabling old split view, adding default shortcuts...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,11 @@ qrc_*.cpp
 ui_*.h
 Makefile*
 *-build-*
+build
 
 # QtCreator
 
 *.autosave
 
+# Kate
+.kateproject.d

--- a/.kateconfig
+++ b/.kateconfig
@@ -1,0 +1,1 @@
+kate: space-indent on; indent-width 4; replace-tabs on;

--- a/.kateproject
+++ b/.kateproject
@@ -1,15 +1,15 @@
 {
       "name": "konsole-multi-terminal"
-    
+
     , "files": [ { "git": 1 } ]
-    
+
     , "build": {
         "directory": "build"
-        
+
       , "build": "make"
-      
+
       , "clean": "make clean"
-      
+
       , "quick": "make"
     }
 }

--- a/.kateproject
+++ b/.kateproject
@@ -1,0 +1,15 @@
+{
+      "name": "konsole-multi-terminal"
+    
+    , "files": [ { "git": 1 } ]
+    
+    , "build": {
+        "directory": "build"
+        
+      , "build": "make"
+      
+      , "clean": "make clean"
+      
+      , "quick": "make"
+    }
+}

--- a/src/MultiTerminalDisplayManager.cpp
+++ b/src/MultiTerminalDisplayManager.cpp
@@ -165,7 +165,7 @@ MultiTerminalDisplay* MultiTerminalDisplayTree::getRootNode() const
 MultiTerminalDisplay* MultiTerminalDisplayTree::traverseTreeAndYeldNodes(MultiTerminalDisplay* currentNode)
 {
     static std::stack<MultiTerminalDisplay*> stack;
-    
+
     if (currentNode && _leaves.contains(currentNode) == false) {
         // Not a leaf, proceed with the children
         stack.push(_parentToChildren[currentNode].first);
@@ -174,7 +174,7 @@ MultiTerminalDisplay* MultiTerminalDisplayTree::traverseTreeAndYeldNodes(MultiTe
 
     // The next node to return
     MultiTerminalDisplay* yeld = NULL;
-    
+
     if (stack.size() > 0) {
         yeld = stack.top();
         stack.pop();
@@ -182,7 +182,7 @@ MultiTerminalDisplay* MultiTerminalDisplayTree::traverseTreeAndYeldNodes(MultiTe
         // After the stack is empty, this method will keep returning NULL
         yeld = NULL;
     }
-    
+
     return yeld;
 }
 
@@ -196,16 +196,9 @@ MultiTerminalDisplayTree::MtdTreeChildren MultiTerminalDisplayTree::getChildrenO
 //  * when a widget is removed, give focus to the one that had it before
 //  * when a different tab is selected, give the focus to the widget that had it
 
-MultiTerminalDisplayManager::MultiTerminalDisplayManager(ViewManager* viewManager
-    , QObject* parent /* = 0 */) :
-    QObject(parent),
-    _viewManager(viewManager),
-    UNSPECIFIED_DISTANCE(-1)
+MultiTerminalDisplayManager::MultiTerminalDisplayManager(ViewManager* viewManager, QObject* parent /* = 0 */) :
+    QObject(parent), _viewManager(viewManager), UNSPECIFIED_DISTANCE(-1)
 {
-    // TODO: connect a signal to the viewDestroyed slot, to finish clearing the sessions.
-    // also check the other connections of ViewManager::createContainer, as we might need them
-    // also put this code every time a mtd is created (helper method)
-   connect(this, SIGNAL(viewRemoved(QWidget*)), _viewManager, SLOT(viewDestroyed(QWidget*)));
 }
 
 MultiTerminalDisplayManager::~MultiTerminalDisplayManager()
@@ -283,7 +276,7 @@ MultiTerminalDisplay* MultiTerminalDisplayManager::removeTerminalDisplay(MultiTe
     // Close the Terminal Display
     TerminalDisplay* removeTd = _mtdContent[mtd];
     removeTd->sessionController()->closeSession();
-    emit viewRemoved(removeTd);
+    emit destroyed(removeTd);
     _mtdContent.remove(mtd);
 
     // Adjust the tree
@@ -481,12 +474,13 @@ MultiTerminalDisplay* MultiTerminalDisplayManager::getRootNode(MultiTerminalDisp
     return tree->getRootNode();
 }
 
+//TODO: I hope this never get used ...
 MultiTerminalDisplay* MultiTerminalDisplayManager::cloneMtd(MultiTerminalDisplay* sourceMtd, ViewContainer* container)
 {
     MultiTerminalDisplayTree* sourceTree = _trees[sourceMtd];
     QSet<MultiTerminalDisplay*> leaves = sourceTree->getLeaves();
     MultiTerminalDisplay* originalRoot = sourceTree->getRootNode();
-    
+
     if (leaves.contains(originalRoot)) {
         // Tree contains a single node, the root which is also leaf
         Session* session = _mtdContent[originalRoot]->sessionController()->session();
@@ -496,7 +490,7 @@ MultiTerminalDisplay* MultiTerminalDisplayManager::cloneMtd(MultiTerminalDisplay
         container->addView(newRoot, td->sessionController());
         return newRoot;
     }
-        
+
     // Prepare an empty root. This is not a leaf, so it will never have a terminalDisplay and session
     MultiTerminalDisplay* newRoot = createRootTerminalDisplay(NULL, NULL, container);
     // This is the node that we are traversing in the original tree, a placeholder for traversing that tree and cloning it
@@ -526,7 +520,7 @@ MultiTerminalDisplay* MultiTerminalDisplayManager::cloneMtd(MultiTerminalDisplay
         }
         nextNode = sourceTree->traverseTreeAndYeldNodes(nextNode);
     }
-    
+
     // Take the ViewProperties from the last TerminalDisplay we used
     container->addView(newRoot, td->sessionController());
     return newRoot;
@@ -573,7 +567,7 @@ void MultiTerminalDisplayManager::splitMultiTerminalDisplay(MultiTerminalDisplay
     QList<int> childSizes;
     childSizes.append(sizes.at(0) / 2);
     childSizes.append(sizes.at(0) / 2);
- 
+
     // Split
     container->setOrientation(orientation);
     container->addWidget(widget1);

--- a/src/MultiTerminalDisplayManager.h
+++ b/src/MultiTerminalDisplayManager.h
@@ -44,16 +44,16 @@ typedef QSplitter MultiTerminalDisplay;
 // TODO: tree in file separato
 
 /*
- * mappa int-tree* 
+ * mappa int-tree*
  * ogni volta che viene creato un nuovo albero, si genera un id e si aggiunge alla mappa
- * 
+ *
  * mappa mtd*-int
  * ogni mtd* e` associato all'indice dell'albero di cui fa parte
- * 
+ *
  * mappa int-set<mtd*> set delle foglie per un albero
- * 
+ *
  * Implementare class MTDTree
- * 
+ *
  * Decisione: c'e` un motivo per non avere direttamente mappa mtd*-tree*, dove ogni mtd e` associato al suo albero?
  * per il momento no, usare questa mappa
  */
@@ -64,7 +64,7 @@ typedef QSplitter MultiTerminalDisplay;
  * <li> Each node has only one parent
  * <li> Each node has zero or two children
  * </ul>
- * 
+ *
  * The tree doesn't keep ownership of the nodes it is made of, the data
  * structure is only used to keep the relationships between the nodes.
  */
@@ -78,7 +78,7 @@ public:
 
     /**
      * Constructor for a new tree.
-     * 
+     *
      * @param rootNode The root node, this will be both root and leaf
      */
     MultiTerminalDisplayTree(MultiTerminalDisplay* rootNode);
@@ -98,10 +98,10 @@ public:
 
     /**
      * Removes a leaf node from the tree and adjust the tree status.
-     * 
+     *
      * The current node is deleted from the tree and its sibling will replace
      * their parent.
-     * 
+     *
      * The algorithm is:
      * * the node that must be deleted (rnode) must be root, or error
      * * if we are removing the root node, we have no tree anymore!
@@ -109,14 +109,14 @@ public:
      *   just replace their parent
      * * basically: take rnode out and put the sibling and its subtree at the place
      *   of the parent
-     * 
+     *
      * If the node is root, it will just be removed.
      */
     void removeNode(MultiTerminalDisplay* node);
 
     /**
      * Returns the sibling of the given node.
-     * 
+     *
      * Unless the node is root, there is always a sibling
      */
     MultiTerminalDisplay* getSiblingOf(MultiTerminalDisplay* node);
@@ -146,22 +146,22 @@ public:
      * Returns the root node of this tree
      */
     MultiTerminalDisplay* getRootNode() const;
-    
+
     /**
      * Traverse the MultiTerminalDisplayTree and returns a pointer to the next
      * node.
      * The pointers are yelded as in python "yeld", each invocation of the method
      * yelds another pointer or NULL if all the tree has been traversed.
-     * 
+     *
      * Tree traversal is done with a stack and it is a depth first traversal.
-     * 
+     *
      * Note that after traversal has started and before it has completed (i.e.,
      * before the method has returned NULL), the method maintains
      * the internal state of the current traversal, so if a new traversal will
      * start at that point, the behavior will be undefined.
      */
     MultiTerminalDisplay* traverseTreeAndYeldNodes(MultiTerminalDisplay* currentNode);
-    
+
     /**
      * Returns the children of the given node in the tree
      */
@@ -184,13 +184,13 @@ private:
 
 /**
  * This is a manager of MultiTerminalDisplay objects.
- * 
+ *
  * MultiTerminalDisplay are splittable objects that can contain either zero
  * or two MultiTerminalDisplay.
- * 
+ *
  * This relationship is represented with a tree of MultiTerminalDisplay
  * objects.
- * 
+ *
  * <ul>
  * <li> The root MultiTerminalDisplay has a NULL parent.
  * <li> Each MultiTerminalDisplay is parent of either zero or two
@@ -226,18 +226,18 @@ public:
     MultiTerminalDisplay* createRootTerminalDisplay(TerminalDisplay* terminalDisplay
         , Session* session
         , ViewContainer* container);
-    
+
     /**
      * This method will promote the currentMultiTerminalDisplay from a leaf
      * to a node with two children.
-     * 
+     *
      * Two new MultiTerminalDisplay leaves will be prepared, one to host the
      * TerminalDisplay which belonged to the currentMultiTerminalDisplay and
      * another to host the new TerminalDisplay which must be added to the screen.
-     * 
+     *
      * The currentMultiTerminalDisplay will then become the parent of the new
      * two MultiTerminalDisplays.
-     * 
+     *
      * \param terminalDisplay The new TerminalDisplay to be added
      * \param session The session that controls the terminalDisplay
      * \param currentMultiTerminalDisplay The MultiTerminalDisplay that must be
@@ -252,7 +252,7 @@ public:
     /**
      * Removes the terminaldisplay contained in the given
      * leaf MultiTerminalDisplay
-     * 
+     *
      * @return The leaf MultiTerminalDisplay that contains the TerminalDisplay
      * that was previously contained in the sibling of the given mtd.
      */
@@ -277,7 +277,7 @@ public:
     /**
      * Given a leaf MultiTerminalDisplay, returns the TerminalDisplay which is
      * closest to that one in the specified direction.
-     * 
+     *
      * @return The closest TerminalDisplay to the given MultiTerminalDisplay in
      * the specified Direction
      */
@@ -293,7 +293,7 @@ public:
     /**
      * Properly shuts down all the terminals, deleting every node
      * of the tree to which the given multiTerminalDisplay belongs.
-     * 
+     *
      * @param multiTerminalDisplay any MultiTerminalDisplay belonging to
      * view that must be shutdown.
      */
@@ -313,11 +313,11 @@ public:
 
     /**
      * Clones a MTD and its hierarchy into the given container.
-     * 
+     *
      * Given a MTD, considers the MTDTree to which that belongs and recreate
      * a new MultiTerminalDisplay that has the same tree and the same terminal
      * sessions.
-     * 
+     *
      * The logic of the method is as follows:
      * * We traverse the original source tree (the one to be cloned) and keep a pointer
      *   to each one of its nodes
@@ -325,7 +325,7 @@ public:
      *   node that corresponds to the current one in the source tree
      * * If the node is a leaf, we add to it the terminalDisplay of the node to which
      *   that corresponds in the source tree
-     * 
+     *
      * @return A MTD that clones the given one
      */
     MultiTerminalDisplay* cloneMtd(MultiTerminalDisplay* sourceMtd, ViewContainer* container);
@@ -355,7 +355,7 @@ private:
 
     /**
      * Puts together a MultiTerminalDisplay and its TerminalDisplay.
-     * 
+     *
      * Helper method.
      */
     void combineMultiTerminalDisplayAndTerminalDisplay(MultiTerminalDisplay* mtd, TerminalDisplay* td);
@@ -393,7 +393,7 @@ private:
     /**
      * For each MultiTerminalDisplay, tells what is the contained
      * TerminalDisplay.
-     * 
+     *
      * Only leave nodes can contain a TerminalDisplay, thus only leaf
      * nodes are key to this Hash.
      */

--- a/src/Part.cpp
+++ b/src/Part.cpp
@@ -64,7 +64,6 @@ Part::Part(QWidget* parentWidget , QObject* parent, const QVariantList&)
 
     // create view widget
     _viewManager = new ViewManager(this, actionCollection());
-    _viewManager->setNavigationMethod(ViewManager::NoNavigation);
 
     connect(_viewManager, SIGNAL(activeViewChanged(SessionController*)), this ,
             SLOT(activeViewChanged(SessionController*)));

--- a/src/ViewManager.cpp
+++ b/src/ViewManager.cpp
@@ -74,7 +74,7 @@ ViewManager::ViewManager(QObject* parent , KActionCollection* collection)
     KAcceleratorManager::setNoAccel(_viewSplitter);
 
     _mtdManager = new MultiTerminalDisplayManager(this);
-    
+
     // the ViewSplitter class supports both recursive and non-recursive splitting,
     // in non-recursive mode, all containers are inserted into the same top-level splitter
     // widget, and all the divider lines between the containers have the same orientation
@@ -148,58 +148,7 @@ void ViewManager::setupActions()
     KAction* moveViewLeftAction = new KAction(i18nc("@action Shortcut entry", "Move Tab Left") , this);
     KAction* moveViewRightAction = new KAction(i18nc("@action Shortcut entry", "Move Tab Right") , this);
 
-    // list of actions that should only be enabled when there are multiple view
-    // containers open
-    QList<QAction*> multiViewOnlyActions;
-    multiViewOnlyActions << nextContainerAction;
-
     if (collection) {
-        KAction* splitLeftRightAction = new KAction(KIcon("view-split-left-right"),
-                i18nc("@action:inmenu", "Split View Left/Right"),
-                this);
-        splitLeftRightAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_ParenLeft));
-        collection->addAction("split-view-left-right", splitLeftRightAction);
-        connect(splitLeftRightAction , SIGNAL(triggered()) , this , SLOT(splitLeftRight()));
-
-        KAction* splitTopBottomAction = new KAction(KIcon("view-split-top-bottom") ,
-                i18nc("@action:inmenu", "Split View Top/Bottom"), this);
-        splitTopBottomAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_ParenRight));
-        collection->addAction("split-view-top-bottom", splitTopBottomAction);
-        connect(splitTopBottomAction , SIGNAL(triggered()) , this , SLOT(splitTopBottom()));
-
-        KAction* closeActiveAction = new KAction(i18nc("@action:inmenu Close Active View", "Close Active") , this);
-        closeActiveAction->setIcon(KIcon("view-close"));
-        closeActiveAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S));
-        closeActiveAction->setEnabled(false);
-        collection->addAction("close-active-view", closeActiveAction);
-        connect(closeActiveAction , SIGNAL(triggered()) , this , SLOT(closeActiveContainer()));
-
-        multiViewOnlyActions << closeActiveAction;
-
-        KAction* closeOtherAction = new KAction(i18nc("@action:inmenu Close Other Views", "Close Others") , this);
-        closeOtherAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_O));
-        closeOtherAction->setEnabled(false);
-        collection->addAction("close-other-views", closeOtherAction);
-        connect(closeOtherAction , SIGNAL(triggered()) , this , SLOT(closeOtherContainers()));
-
-        multiViewOnlyActions << closeOtherAction;
-
-        // Expand & Shrink Active View
-        KAction* expandActiveAction = new KAction(i18nc("@action:inmenu", "Expand View") , this);
-        expandActiveAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_BracketRight));
-        expandActiveAction->setEnabled(false);
-        collection->addAction("expand-active-view", expandActiveAction);
-        connect(expandActiveAction , SIGNAL(triggered()) , this , SLOT(expandActiveContainer()));
-
-        multiViewOnlyActions << expandActiveAction;
-
-        KAction* shrinkActiveAction = new KAction(i18nc("@action:inmenu", "Shrink View") , this);
-        shrinkActiveAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_BracketLeft));
-        shrinkActiveAction->setEnabled(false);
-        collection->addAction("shrink-active-view", shrinkActiveAction);
-        connect(shrinkActiveAction , SIGNAL(triggered()) , this , SLOT(shrinkActiveContainer()));
-
-        multiViewOnlyActions << shrinkActiveAction;
 
 #if defined(ENABLE_DETACHING)
         KAction* detachViewAction = collection->addAction("detach-view");
@@ -228,34 +177,35 @@ void ViewManager::setupActions()
         for (int i = 0; i < SWITCH_TO_TAB_COUNT; i++) {
             KAction* switchToTabAction = new KAction(i18nc("@action Shortcut entry", "Switch to Tab %1", i + 1), this);
             switchToTabMapper->setMapping(switchToTabAction, i);
-            connect(switchToTabAction, SIGNAL(triggered()), switchToTabMapper,
-                    SLOT(map()));
+            connect(switchToTabAction, SIGNAL(triggered()), switchToTabMapper, SLOT(map()));
             collection->addAction(QString("switch-to-tab-%1").arg(i), switchToTabAction);
         }
     }
 
-    // TODO: add the & in the strigs for the menu shortcuts to
+    // Menu item for the vertical split of the multi terminal
+    KAction* multiTerminalVerAction = new KAction(KIcon("view-split-left-right"), i18nc("@action:inmenu", "Split Pane &Vertically"), this);
+    multiTerminalVerAction->setEnabled(true);
+    multiTerminalVerAction->setShortcut(QKeySequence(Qt::META + Qt::Key_D));
+    collection->addAction("multi-terminal-ver", multiTerminalVerAction);
+    _viewSplitter->addAction(multiTerminalVerAction);
+    connect(multiTerminalVerAction, SIGNAL(triggered()), this, SLOT(multiTerminalVertical()));
+
 
     // Menu item for the horizontal split of the multi terminal
-    KAction* multiTerminalHorAction = collection->addAction("multi-terminal-hor");
-    multiTerminalHorAction->setText(i18nc("@action:inmenu", "Split horizontally"));
-    connect(multiTerminalHorAction , SIGNAL(triggered()) , this , SLOT(multiTerminalHorizontal()));
+    KAction* multiTerminalHorAction = new KAction(KIcon("view-split-top-bottom"), i18nc("@action:inmenu", "Split Pane &Horizontally"), this);
+    multiTerminalHorAction->setEnabled(true);
+    multiTerminalHorAction->setShortcut(QKeySequence(Qt::META + Qt::CTRL + Qt::Key_D));
+    collection->addAction("multi-terminal-hor", multiTerminalHorAction);
+    _viewSplitter->addAction(multiTerminalHorAction);
+    connect(multiTerminalHorAction, SIGNAL(triggered()), this, SLOT(multiTerminalHorizontal()));
 
-    // Menu item for the vertical split of the multi terminal
-    KAction* multiTerminalVerAction = collection->addAction("multi-terminal-ver");
-    multiTerminalVerAction->setText(i18nc("@action:inmenu", "Split vertically"));
-    connect(multiTerminalVerAction , SIGNAL(triggered()) , this , SLOT(multiTerminalVertical()));
 
     // Menu item for closing a multi terminal
-    // TODO: this must be disabled when no splits
-    KAction* closeMultiTerminalAction = collection->addAction("multi-terminal-close");
-    closeMultiTerminalAction->setText(i18nc("@action:inmenu", "Close Multi Terminal"));
-    closeMultiTerminalAction->setEnabled(false);
-    connect(closeMultiTerminalAction , SIGNAL(triggered()) , this , SLOT(multiTerminalClose()));
-    // This action must be enabled only when there is more than one multi-terminal
-    // TODO: if this is enabled, calling this closes the tab, use this info to fix the problem
-    // of the close tab button that doesn't work
-    connect(this, SIGNAL(closeMultiTerminalToggle(bool)), closeMultiTerminalAction, SLOT(setEnabled(bool)));
+    KAction* closeMultiTerminalAction = new KAction(KIcon("view-close"), i18nc("@action:inmenu", "&Close"), this);
+    closeMultiTerminalAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_W));
+    collection->addAction("multi-terminal-close", closeMultiTerminalAction);
+    _viewSplitter->addAction(closeMultiTerminalAction);
+    connect(closeMultiTerminalAction, SIGNAL(triggered()), this, SLOT(multiTerminalClose()));
 
     // Shortcut to move to the MTD to the left
     KAction* goToLeftMtdAction = 0;
@@ -285,10 +235,6 @@ void ViewManager::setupActions()
     // TODO: icon?
     goToBottomMtdAction->setIcon(KIcon("edit-rename"));
     goToBottomMtdAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_Down));
-    
-    foreach(QAction* action, multiViewOnlyActions) {
-        connect(this , SIGNAL(splitViewToggle(bool)) , action , SLOT(setEnabled(bool)));
-    }
 
     // keyboard shortcut only actions
     nextViewAction->setShortcut(QKeySequence(Qt::SHIFT + Qt::Key_Right));
@@ -319,9 +265,6 @@ void ViewManager::switchToView(int index)
     Q_ASSERT(index >= 0);
     ViewContainer* container = _viewSplitter->activeContainer();
     Q_ASSERT(container);
-    // TODO: sarebbero tutti i root terminal display, ma equivalgono
-    // alle view storate dal container
-    // QList<QWidget*> containerViews = getTerminalsFromContainer(container);
     QList<QWidget*> containerViews = container->views();
     if (index >= containerViews.count()) {
         return;
@@ -336,7 +279,6 @@ void ViewManager::updateDetachViewState()
     const bool splitView = _viewSplitter->containers().count() >= 2;
     const bool shouldEnable = splitView ||
                               _viewSplitter->activeContainer()->views().count() >= 2;
-                              //getTerminalsFromContainer(_viewSplitter->activeContainer()).count() >= 2;
 
     QAction* detachAction = _actionCollection->action("detach-view");
 
@@ -400,7 +342,7 @@ void ViewManager::detachView(ViewContainer* container, QWidget* widgetView)
 #if !defined(ENABLE_DETACHING)
     return;
 #endif
-    
+
     MultiTerminalDisplay * viewToDetach = qobject_cast<MultiTerminalDisplay*>(widgetView);
 
     if (!viewToDetach)
@@ -424,7 +366,6 @@ void ViewManager::detachView(ViewContainer* container, QWidget* widgetView)
     // so that there is always an active container
     if (_viewSplitter->containers().count() > 1 &&
             container->views().count() == 0) {
-            // getTerminalsFromContainer(container).count() == 0) {
         removeContainer(container);
     }
 }
@@ -441,7 +382,7 @@ void ViewManager::sessionFinished()
     Q_ASSERT(session);
 
     // TODO: all multi terminals must be removed as well
-    
+
     // close attached views
     QList<TerminalDisplay*> children = _viewSplitter->findChildren<TerminalDisplay*>();
 
@@ -485,78 +426,19 @@ void ViewManager::viewActivated(QWidget* view)
     view->setFocus(Qt::OtherFocusReason);
 }
 
-void ViewManager::splitLeftRight()
-{
-    splitView(Qt::Horizontal);
-}
-void ViewManager::splitTopBottom()
-{
-    splitView(Qt::Vertical);
-}
-
-void ViewManager::splitView(Qt::Orientation orientation)
-{
-    ViewContainer* container = createContainer();
-
-    // iterate over each session which has a view in the current active
-    // container and create a new view for that session in a new container
-    // TODO XXX: non va bene: prima era _viewSplitter->activeContainer()->views() che
-    //       per un tab container significava tutte le tabs (1 tab per TerminalDisplay).
-    //       Ora sono i TerminalDisplay in una singola tab.
-    // foreach(QWidget* view,  getTerminalsFromContainer(_viewSplitter->activeContainer())) {
-    
-    
-    // For each view of the container (for each tab): _viewSplitter->activeContainer()->views()
-    // Get the tree of MTDs of that Tab
-    // Create a widget that contains all the subwidgets (the MTD tree) but uses the same terminal sessions
-    // Add this widget (i.e., tab) to the new container (created above)
-    
-    foreach (QWidget* view, _viewSplitter->activeContainer()->views()) {
-        MultiTerminalDisplay* mtd = qobject_cast<MultiTerminalDisplay*>(view);
-        if (!mtd) {
-            kError() << "Cannot cast container view to MultiTerminalDisplay";
-            return;
-        }
-
-        _mtdManager->cloneMtd(mtd, container);
-    }
-
-    _viewSplitter->addContainer(container, orientation);
-    emit splitViewToggle(_viewSplitter->containers().count() > 0);
-
-    // focus the new container
-    container->containerWidget()->setFocus();
-
-    // ensure that the active view is focused after the split / unsplit
-    ViewContainer* activeContainer = _viewSplitter->activeContainer();
-    QWidget* activeView = activeContainer ? activeContainer->activeView() : 0;
-
-    if (activeView)
-        activeView->setFocus(Qt::OtherFocusReason);
-}
 void ViewManager::removeContainer(ViewContainer* container)
 {
-    // TODO: remove all the multiterminals
-    // remove session map entries for views in this container
-    foreach(QWidget* view , getTerminalsFromContainer(container)) {
-        TerminalDisplay* display = qobject_cast<TerminalDisplay*>(view);
-        Q_ASSERT(display);
-        _sessionMap.remove(display);
-    }
+//     // TODO: remove all the multiterminals
+//     // remove session map entries for views in this container
+//     foreach(QWidget* view , _mtdManager->getTerminalDisplays()) {
+//         TerminalDisplay* display = qobject_cast<TerminalDisplay*>(view);
+//         Q_ASSERT(display);
+//         _sessionMap.remove(display);
+//     }
+//     _viewSplitter->removeContainer(container);
+//     container->deleteLater();
+}
 
-    _viewSplitter->removeContainer(container);
-    container->deleteLater();
-
-    emit splitViewToggle(_viewSplitter->containers().count() > 1);
-}
-void ViewManager::expandActiveContainer()
-{
-    _viewSplitter->adjustContainerSize(_viewSplitter->activeContainer(), 10);
-}
-void ViewManager::shrinkActiveContainer()
-{
-    _viewSplitter->adjustContainerSize(_viewSplitter->activeContainer(), -10);
-}
 void ViewManager::multiTerminalHorizontal()
 {
     // This is called from the menu action
@@ -572,8 +454,8 @@ void ViewManager::multiTerminalVertical()
 
 void ViewManager::multiTerminalClose()
 {
-    // TODO: which one?
-//     MultiTerminalDisplay* containerMtd = _viewSplitter->activeSplitter()->activeContainer()->activeView();
+    // TODO: make sure we close the one that has focused.
+
     MultiTerminalDisplay* containerMtd = qobject_cast<MultiTerminalDisplay*>(_viewSplitter->activeContainer()->activeView());
 
     // MultiTerminalDisplay with focus
@@ -582,10 +464,10 @@ void ViewManager::multiTerminalClose()
 
     _mtdManager->removeTerminalDisplay(mtd);
 
-    if (_mtdManager->getNumberOfNodes(root) == 1) {
-        // There will be only one terminal left in this view.
-        // Disable the multi terminal close button
-        emit closeMultiTerminalToggle(false);
+    // TODO: make sure this does not kill all the app when there are remaining tabs
+    if (_mtdManager->getNumberOfNodes(root) == 0) {
+        // no more terminal, let's exit()
+        exit(0);
     }
 
     //_mtdManager->dismissMultiTerminals(mtd);
@@ -621,29 +503,6 @@ void ViewManager::moveMtdFocus(MultiTerminalDisplayManager::Directions direction
     }
 }
 
-
-void ViewManager::closeActiveContainer()
-{
-    // only do something if there is more than one container active
-    if (_viewSplitter->containers().count() > 1) {
-        ViewContainer* container = _viewSplitter->activeContainer();
-
-        removeContainer(container);
-
-        // focus next container so that user can continue typing
-        // without having to manually focus it themselves
-        nextContainer();
-    }
-}
-void ViewManager::closeOtherContainers()
-{
-    ViewContainer* active = _viewSplitter->activeContainer();
-
-    foreach(ViewContainer* container, _viewSplitter->containers()) {
-        if (container != active)
-            removeContainer(container);
-    }
-}
 
 SessionController* ViewManager::createController(Session* session , TerminalDisplay* view)
 {
@@ -749,7 +608,6 @@ void ViewManager::createView(Session* session)
         kDebug() << "void ViewManager::createView, we are creating the default container";
         ViewContainer* container = createContainer();
         _viewSplitter->addContainer(container, Qt::Vertical);
-        emit splitViewToggle(false);
     }
 
     // new tab will be put at the end by default.
@@ -758,7 +616,6 @@ void ViewManager::createView(Session* session)
     if (_newTabBehavior == PutNewTabAfterCurrentTab) {
         QWidget* view = activeView();
         if (view) {
-            //QList<QWidget*> views =  getTerminalsFromContainer(_viewSplitter->activeContainer());
             QList<QWidget*> views = _viewSplitter->activeContainer()->views();
             index = views.indexOf(view) + 1;
         }
@@ -808,9 +665,6 @@ void ViewManager::createMultiTerminalView(Qt::Orientation orientation)
     session->setDarkBackground(colorSchemeForProfile(profile)->hasDarkBackground());
 
     updateDetachViewState();
-
-    // Enable the close button
-    emit closeMultiTerminalToggle(true);
 }
 
 ViewContainer* ViewManager::createContainer()
@@ -895,53 +749,7 @@ void ViewManager::containerMoveViewRequest(int index, int id, bool& moved, Tabbe
     moved = true;
 }
 
-void ViewManager::setNavigationMethod(NavigationMethod method)
-{
-    _navigationMethod = method;
 
-    KActionCollection* collection = _actionCollection;
-
-    if (collection) {
-        // FIXME: The following disables certain actions for the KPart that it
-        // doesn't actually have a use for, to avoid polluting the action/shortcut
-        // namespace of an application using the KPart (otherwise, a shortcut may
-        // be in use twice, and the user gets to see an "ambiguous shortcut over-
-        // load" error dialog). However, this approach sucks - it's the inverse of
-        // what it should be. Rather than disabling actions not used by the KPart,
-        // a method should be devised to only enable those that are used, perhaps
-        // by using a separate action collection.
-
-        const bool enable = (_navigationMethod != NoNavigation);
-        QAction* action;
-
-        action = collection->action("next-view");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("previous-view");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("last-tab");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("split-view-left-right");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("split-view-top-bottom");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("rename-session");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("move-view-left");
-        if (action) action->setEnabled(enable);
-
-        action = collection->action("move-view-right");
-        if (action) action->setEnabled(enable);
-        
-        action = collection->action("multi-terminal");
-        if (action) action->setEnabled(enable);
-    }
-}
 
 ViewManager::NavigationMethod ViewManager::navigationMethod() const
 {
@@ -1128,7 +936,7 @@ QList<ViewProperties*> ViewManager::viewProperties() const
 
     Q_ASSERT(container);
 
-    foreach(QWidget* view, getTerminalsFromContainer(container)) {
+    foreach(QWidget* view, _mtdManager->getTerminalDisplays()) {
         ViewProperties* properties = container->viewProperties(view);
         Q_ASSERT(properties);
         list << properties;
@@ -1148,7 +956,7 @@ void ViewManager::saveSessions(KConfigGroup& group)
     Q_ASSERT(container);
     TerminalDisplay* activeview = qobject_cast<TerminalDisplay*>(container->activeView());
 
-    QListIterator<QWidget*> viewIter(getTerminalsFromContainer(container));
+    QListIterator<QWidget*> viewIter(_mtdManager->getTerminalDisplays());
     int tab = 1;
     while (viewIter.hasNext()) {
         TerminalDisplay* view = qobject_cast<TerminalDisplay*>(viewIter.next());
@@ -1355,17 +1163,10 @@ void ViewManager::setNavigationBehavior(int behavior)
     _newTabBehavior = static_cast<NewTabBehavior>(behavior);
 }
 
+// TODO: remove this...
 QList<QWidget*> ViewManager::getTerminalsFromContainer(ViewContainer *container) const
 {
     return _mtdManager->getTerminalDisplays();
-
-//     QList<QWidget*> l;
-//     foreach (QWidget* widget, container->views()) {
-//         // Loop over all the root MultiTerminalDisplays in the container (e.g., the tabs)
-//         MultiTerminalDisplay* mtd = qobject_cast<MultiTerminalDisplay*>(widget);
-//         l.append(mtd->getTerminalDisplays());
-//     }
-//     return l;
 }
 
 #include "ViewManager.moc"

--- a/src/ViewManager.h
+++ b/src/ViewManager.h
@@ -89,7 +89,7 @@ public:
      * Creates a multi-terminal view.
      */
     void createMultiTerminalView(Qt::Orientation orientation);
-    
+
     /**
      * Applies the view-specific settings associated with specified @p profile
      * to the terminal display @p view.
@@ -166,7 +166,7 @@ public:
      * Returns the search bar.
      */
     IncrementalSearchBar* searchBar() const;
-    
+
     /**
      * Creates a new terminal display and updates the internal status of the
      * ViewManager.
@@ -216,23 +216,6 @@ signals:
      * if the active container is changed.
      */
     void viewPropertiesChanged(const QList<ViewProperties*>& propertiesList);
-
-    /**
-     * Emitted when the number of views containers changes.  This is used to disable or
-     * enable menu items which can only be used when there are one or multiple containers
-     * visible.
-     *
-     * @param multipleViews True if there are multiple view containers open or false if there is
-     * just a single view.
-     */
-    void splitViewToggle(bool multipleViews);
-
-    /**
-     * Emitted when there is more than one multi-terminal open.
-     * @param multiTerminals True if there is more than one multi-terminal open for the current
-     * view
-     */
-    void closeMultiTerminalToggle(bool multiTerminals);
 
     /**
      * Emitted when menu bar visibility changes because a profile that requires so is
@@ -296,14 +279,7 @@ public slots:
     Q_SCRIPTABLE void setTabWidthToText(bool);
 
 private slots:
-    // called when the "Split View Left/Right" menu item is selected
-    void splitLeftRight();
-    void splitTopBottom();
-    void closeActiveContainer();
-    void closeOtherContainers();
-    void expandActiveContainer();
-    void shrinkActiveContainer();
-    
+
     void multiTerminalHorizontal();
     void multiTerminalVertical();
     void multiTerminalClose();
@@ -312,7 +288,7 @@ private slots:
     void moveToTopMtd();
     void moveToRightMtd();
     void moveToBottomMtd();
-    
+
     // Moves the focus from the current widget to the closest one in the given direction
     void moveMtdFocus(MultiTerminalDisplayManager::Directions direction);
 
@@ -424,7 +400,7 @@ private:
 
     int _managerId;
     static int lastManagerId;
-    
+
     MultiTerminalDisplayManager* _mtdManager;
 };
 }


### PR DESCRIPTION
so, code quality is NOT really good... I just hack this together to make it work more like I wanted it to behave.
- old split options are not readilly available, but there sure remain codes to delete.
- options in the menu no longer appears and I did not care too much
- I use keyboard shortcuts, I used something similar to what iTerm2 on OSX has a default
  Meta-d to split horizontally and Meta-Ctrl-d to split vertically
- Meta-w close that has focused.
- we still have that bug where the window remains open with no more terminal after closing the last one
- simplify code where I could, reusing existing signals instead of creating new ones...
